### PR TITLE
Fixes an issue where camera state is always Recording

### DIFF
--- a/custom_components/badnest/camera.py
+++ b/custom_components/badnest/camera.py
@@ -69,7 +69,6 @@ class NestCamera(Camera):
 
     @property
     def is_recording(self):
-        return True
         """Return true if the device is recording."""
         return self._device.device_data[self._uuid]['is_streaming']
 


### PR DESCRIPTION
is_recording() was hard coded to always return true, this commit
introduces a fix so that is_streaming state is returned instead